### PR TITLE
Fixes wrong class comparisons 

### DIFF
--- a/src/Bundle/LongRunningBundle/DependencyInjection/Compiler/MonologCleanersPass.php
+++ b/src/Bundle/LongRunningBundle/DependencyInjection/Compiler/MonologCleanersPass.php
@@ -15,7 +15,7 @@ class MonologCleanersPass implements CompilerPassInterface
             $fingersCrossedServiceReferences = [];
             foreach ($container->getDefinitions() as $serviceId => $definition) {
                 $class = $container->getParameterBag()->resolveValue($definition->getClass());
-                if ($class === 'Monolog\Handler\FingersCrossedHandler') {
+                if (is_a($class, 'Monolog\Handler\FingersCrossedHandler', true)) {
                     $fingersCrossedServiceReferences[] = new Reference($serviceId);
                 }
             }
@@ -29,7 +29,7 @@ class MonologCleanersPass implements CompilerPassInterface
             $bufferHandlerServiceReferences = [];
             foreach ($container->getDefinitions() as $serviceId => $definition) {
                 $class = $container->getParameterBag()->resolveValue($definition->getClass());
-                if ($class === 'Monolog\Handler\BufferHandler') {
+                if (is_a($class, 'Monolog\Handler\BufferHandler', true)) {
                     $bufferHandlerServiceReferences[] = new Reference($serviceId);
                 }
             }

--- a/src/Bundle/LongRunningBundle/DependencyInjection/Compiler/SwiftMailerPass.php
+++ b/src/Bundle/LongRunningBundle/DependencyInjection/Compiler/SwiftMailerPass.php
@@ -28,11 +28,11 @@ class SwiftMailerPass implements CompilerPassInterface
                 $transport = sprintf('swiftmailer.mailer.%s.transport', $name);
                 $transportDefinition = $container->findDefinition($transport);
 
-                if (is_a('Swift_Transport_SpoolTransport', $transportDefinition->getClass(), true)) {
+                if (is_a($transportDefinition->getClass(), 'Swift_Transport_SpoolTransport', true)) {
                     $spool = sprintf('swiftmailer.mailer.%s.spool', $name);
                     $spoolDefinition = $container->findDefinition($spool);
 
-                    if (is_a('Swift_MemorySpool', $spoolDefinition->getClass(), true)) {
+                    if (is_a($spoolDefinition->getClass(), 'Swift_MemorySpool', true)) {
                         $realTransport = sprintf('swiftmailer.mailer.%s.transport.real', $name);
                         $spoolServiceReferences[$name] = new Reference($spool);
                         $realTransportServiceReferences[$name] = new Reference($realTransport);


### PR DESCRIPTION
In my pull request for the monolog i did not use the is_a to check for instances where people extended the handlers this pull requests fixes that tnx @lyrixx for noticing that.
https://github.com/cmodijk/LongRunning/commit/5bd800be69003c6c004e5b1b3a0d4623f8640c86#commitcomment-10715706

I also fixed the `SwiftMailerPass` because i compared the classes the wrong way. 
