### PR TITLE
Add automatic registration for monolog and swiftmailer

### DIFF
--- a/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
+++ b/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
@@ -72,6 +72,20 @@ class LongRunningExtension extends ConfigurableExtension implements PrependExten
                 ]
             ]);
         }
+        if (isset($enabledBundles['MonologBundle'])) {
+            $container->prependExtensionConfig($this->getAlias(), [
+                'monolog' => [
+                    'enabled' => true
+                ]
+            ]);
+        }
+        if (isset($enabledBundles['SwiftmailerBundle'])) {
+            $container->prependExtensionConfig($this->getAlias(), [
+                'swift_mailer' => [
+                    'enabled' => true
+                ]
+            ]);
+        }
         if (isset($enabledBundles['SimpleBusRabbitMQBundle'])) {
             $container->prependExtensionConfig($this->getAlias(), [
                 'simple_bus_rabbit_mq' => [


### PR DESCRIPTION
This pull request add's the auto registration for the cleaners when MonologBundle or SwiftmailerBundle are enabled.
