### PR TITLE
Also clear the EntityManagerInterface

### DIFF
--- a/src/Plugin/DoctrineORMPlugin/ResetClosedEntityManagers.php
+++ b/src/Plugin/DoctrineORMPlugin/ResetClosedEntityManagers.php
@@ -4,6 +4,7 @@ namespace LongRunning\Plugin\DoctrineORMPlugin;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use LongRunning\Core\Cleaner;
 use Psr\Log\LoggerInterface;
 
@@ -28,7 +29,7 @@ class ResetClosedEntityManagers implements Cleaner
     public function cleanUp()
     {
         foreach ($this->managerRegistry->getManagers() as $name => $manager) {
-            if (!($manager instanceof EntityManager)) {
+            if (!($manager instanceof EntityManager || $manager instanceof EntityManagerInterface)) {
                 continue;
             }
 


### PR DESCRIPTION
Since doctrine 2.4 you could get an object with the EntityManagerInterface instead of the EntityManager this fixes the 2 different cases.  
