### PR TITLE
Remove minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,5 @@
         "psr-4": {
             "LongRunning\\Tests\\": "tests"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
Remove the minimum-stability and prefer-stable to fix the memory issues on php 5.6