### PR TITLE
Sentry > Also clear breadcrumbs of errors

### DIFF
--- a/src/Plugin/SentryPlugin/ClearSentryErrors.php
+++ b/src/Plugin/SentryPlugin/ClearSentryErrors.php
@@ -28,5 +28,6 @@ class ClearSentryErrors implements Cleaner
     {
         $this->logger->debug('Flush sentry errors');
         $this->sentry->sendUnsentErrors();
+        $this->sentry->breadcrumbs->reset();
     }
 }

--- a/tests/Plugin/SentryPlugin/ClearSentryErrorsTest.php
+++ b/tests/Plugin/SentryPlugin/ClearSentryErrorsTest.php
@@ -23,6 +23,11 @@ class ClearSentryErrorsTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('sendUnsentErrors');
 
+        $sentry
+            ->breadcrumbs
+            ->expects($this->once())
+            ->method('reset');
+
         $cleaner = new ClearSentryErrors($sentry,  $logger);
         $cleaner->cleanUp();
     }
@@ -32,7 +37,21 @@ class ClearSentryErrorsTest extends \PHPUnit_Framework_TestCase
      */
     private function getSentry()
     {
-        return $this->getMockBuilder('Sentry\SentryBundle\SentrySymfonyClient')
+        $sentry = $this->getMockBuilder('Sentry\SentryBundle\SentrySymfonyClient')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sentry->breadcrumbs = $this->getBreadcrumbs();
+
+        return $sentry;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Raven_Breadcrumbs
+     */
+    private function getBreadcrumbs()
+    {
+        return $this->getMockBuilder('Raven_Breadcrumbs')
             ->disableOriginalConstructor()
             ->getMock();
     }


### PR DESCRIPTION
When adding the Sentry plugin here #24 I forgot to also reset the breadcrumbs. 