### PR TITLE
alias long_running.delegating_cleaner to class name for easier auto-wiring

### DIFF
--- a/src/Bundle/LongRunningBundle/Resources/config/services.yml
+++ b/src/Bundle/LongRunningBundle/Resources/config/services.yml
@@ -4,3 +4,6 @@ services:
         arguments:
             # will be populated by RegisterCleanersPass
             - []
+
+    LongRunning\Core\DelegatingCleaner:
+        alias: long_running.delegating_cleaner


### PR DESCRIPTION
when auto wiring is on, it makes it easier to inject the cleaner into custom service (eg: for integration with other consumer types)