### PR TITLE
Rollback when connection is marked for rollback only

### DIFF
--- a/tests/Plugin/DoctrineDBALPlugin/CloseConnectionsTest.php
+++ b/tests/Plugin/DoctrineDBALPlugin/CloseConnectionsTest.php
@@ -2,9 +2,12 @@
 
 namespace LongRunning\Tests\Plugin\DoctrineDBALPlugin;
 
+use Doctrine\Common\Persistence\ConnectionRegistry;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ConnectionException;
 use LongRunning\Plugin\DoctrineDBALPlugin\CloseConnections;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class CloseConnectionsTest extends TestCase
 {
@@ -18,19 +21,125 @@ class CloseConnectionsTest extends TestCase
             'second'    => $this->getConnection(),
         ];
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ConnectionRegistry');
+        $registry = $this->createMock(ConnectionRegistry::class);
         $registry
             ->expects($this->once())
             ->method('getConnections')
             ->willReturn($connections);
 
-        $logger = $this->createMock('Psr\Log\LoggerInterface');
-        foreach (array_keys($connections) as $count => $name) {
-            $logger
-                ->expects($this->at($count))
-                ->method('debug')
-                ->with('Close database connection', ['connection' => $name]);
-        }
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->exactly(2))
+            ->method('debug')
+            ->withConsecutive(
+                ['Close database connection', ['connection' => 'default']],
+                ['Close database connection', ['connection' => 'second']]
+            );
+
+        $cleaner = new CloseConnections($registry, $logger);
+        $cleaner->cleanUp();
+    }
+
+    /**
+     * @test
+     */
+    public function it_rolls_back_when_in_rollback_only_mode()
+    {
+        $connections = [
+            'default'   => $this->getConnection(),
+            'second'    => $this->getConnection(),
+        ];
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('isTransactionActive')
+            ->willReturn(true);
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('isRollbackOnly')
+            ->willReturn(true);
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('rollBack');
+
+        $registry = $this->createMock(ConnectionRegistry::class);
+        $registry
+            ->expects($this->once())
+            ->method('getConnections')
+            ->willReturn($connections);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logger
+            ->expects($this->once())
+            ->method('notice')
+            ->with('Rolling back active transaction in rollback only state', ['connection' => 'default']);
+
+        $logger
+            ->expects($this->exactly(2))
+            ->method('debug')
+            ->withConsecutive(
+                ['Close database connection', ['connection' => 'default']],
+                ['Close database connection', ['connection' => 'second']]
+            );
+
+        $cleaner = new CloseConnections($registry, $logger);
+        $cleaner->cleanUp();
+    }
+
+    /**
+     * @test
+     */
+    public function it_rolls_back_when_in_rollback_only_mode_and_catches_any_exception()
+    {
+        $connections = [
+            'default'   => $this->getConnection(),
+            'second'    => $this->getConnection(),
+        ];
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('isTransactionActive')
+            ->willReturn(true);
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('isRollbackOnly')
+            ->willReturn(true);
+
+        $connections['default']->expects($this->atLeastOnce())
+            ->method('rollBack')
+            ->willThrowException(ConnectionException::noActiveTransaction());
+
+        $connections['second']->expects($this->atLeastOnce())
+            ->method('isTransactionActive')
+            ->willReturn(false);
+
+        $registry = $this->createMock(ConnectionRegistry::class);
+        $registry
+            ->expects($this->once())
+            ->method('getConnections')
+            ->willReturn($connections);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $logger
+            ->expects($this->once())
+            ->method('notice')
+            ->with('Rolling back active transaction in rollback only state', ['connection' => 'default']);
+
+        $logger
+            ->expects($this->once())
+            ->method('error')
+            ->with('Rolling back active transaction failed', [
+                'connection' => 'default',
+                'exception' => 'There is no active transaction.'
+            ]);
+
+        $logger
+            ->expects($this->exactly(2))
+            ->method('debug')
+            ->withConsecutive(
+                ['Close database connection', ['connection' => 'default']],
+                ['Close database connection', ['connection' => 'second']]
+            );
 
         $cleaner = new CloseConnections($registry, $logger);
         $cleaner->cleanUp();
@@ -44,7 +153,7 @@ class CloseConnectionsTest extends TestCase
      */
     public function it_throws_exception_with_wrong_connection()
     {
-        $registry = $this->createMock('Doctrine\Common\Persistence\ConnectionRegistry');
+        $registry = $this->createMock(ConnectionRegistry::class);
         $registry
             ->expects($this->once())
             ->method('getConnections')
@@ -52,7 +161,7 @@ class CloseConnectionsTest extends TestCase
                 'default' => new \stdClass(),
             ]);
 
-        $logger = $this->createMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $cleaner = new CloseConnections($registry, $logger);
         $cleaner->cleanUp();
@@ -63,7 +172,7 @@ class CloseConnectionsTest extends TestCase
      */
     private function getConnection()
     {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+        $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
When you begin a transaction and the commit operation fails, you should always rollback and close the connection.

If you forget this, and rely on the cleaner, the next invoked code gets a connection in a dirty state.