### PR TITLE
Automatically configure services that implement Cleaner interface

### DIFF
--- a/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
+++ b/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
@@ -54,6 +54,10 @@ class LongRunningExtension extends ConfigurableExtension implements PrependExten
         if ($mergedConfig['simple_bus_rabbit_mq']['enabled']) {
             $loader->load('simple_bus_rabbit_mq.yml');
         }
+
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container->registerForAutoconfiguration(Cleaner::class)->addTag('long_running.cleaner');
+        }
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)


### PR DESCRIPTION
This makes it easier to add new cleaners for Symfony 3.4+ with auto configuration.