### PR TITLE
Sentry v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "simple-bus/rabbitmq-bundle-bridge": "~2.1 || ~4.0",
         "symfony/monolog-bundle": "^3.1.2",
         "symfony/swiftmailer-bundle": "~2.3 || ~3.2",
-        "sentry/sentry-symfony": "~1.0 || ~2.0"
+        "sentry/sentry-symfony": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bundle/LongRunningBundle/Resources/config/sentry.yml
+++ b/src/Bundle/LongRunningBundle/Resources/config/sentry.yml
@@ -3,7 +3,7 @@ services:
         class: LongRunning\Plugin\SentryPlugin\ClearSentryErrors
         public: false
         arguments:
-            - '@sentry.client'
+            - '@Sentry\ClientInterface'
             - '@logger'
         tags:
             - { name: long_running.cleaner }

--- a/src/Plugin/SentryPlugin/ClearSentryErrors.php
+++ b/src/Plugin/SentryPlugin/ClearSentryErrors.php
@@ -4,7 +4,7 @@ namespace LongRunning\Plugin\SentryPlugin;
 
 use LongRunning\Core\Cleaner;
 use Psr\Log\LoggerInterface;
-use Sentry\SentryBundle\SentrySymfonyClient;
+use Sentry\FlushableClientInterface;
 
 class ClearSentryErrors implements Cleaner
 {
@@ -14,11 +14,11 @@ class ClearSentryErrors implements Cleaner
     private $logger;
 
     /**
-     * @var SentrySymfonyClient
+     * @var FlushableClientInterface
      */
     private $sentry;
 
-    public function __construct(SentrySymfonyClient $sentry,  LoggerInterface $logger)
+    public function __construct(FlushableClientInterface $sentry,  LoggerInterface $logger)
     {
         $this->sentry = $sentry;
         $this->logger = $logger;
@@ -27,7 +27,6 @@ class ClearSentryErrors implements Cleaner
     public function cleanUp()
     {
         $this->logger->debug('Flush sentry errors');
-        $this->sentry->sendUnsentErrors();
-        $this->sentry->breadcrumbs->reset();
+        $this->sentry->flush();
     }
 }

--- a/tests/Plugin/SentryPlugin/ClearSentryErrorsTest.php
+++ b/tests/Plugin/SentryPlugin/ClearSentryErrorsTest.php
@@ -4,7 +4,8 @@ namespace LongRunning\Tests\Plugin\SentryPlugin;
 
 use LongRunning\Plugin\SentryPlugin\ClearSentryErrors;
 use PHPUnit\Framework\TestCase;
-use Sentry\SentryBundle\SentrySymfonyClient;
+use Sentry\ClientInterface;
+use Sentry\FlushableClientInterface;
 
 class ClearSentryErrorsTest extends TestCase
 {
@@ -22,38 +23,21 @@ class ClearSentryErrorsTest extends TestCase
         $sentry = $this->getSentry();
         $sentry
             ->expects($this->once())
-            ->method('sendUnsentErrors');
-
-        $sentry
-            ->breadcrumbs
-            ->expects($this->once())
-            ->method('reset');
+            ->method('flush');
 
         $cleaner = new ClearSentryErrors($sentry,  $logger);
         $cleaner->cleanUp();
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|SentrySymfonyClient
+     * @return \PHPUnit_Framework_MockObject_MockObject|ClientInterface
      */
     private function getSentry()
     {
-        $sentry = $this->getMockBuilder('Sentry\SentryBundle\SentrySymfonyClient')
+        $sentry = $this->getMockBuilder('Sentry\FlushableClientInterface')
             ->disableOriginalConstructor()
             ->getMock();
-
-        $sentry->breadcrumbs = $this->getBreadcrumbs();
 
         return $sentry;
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Raven_Breadcrumbs
-     */
-    private function getBreadcrumbs()
-    {
-        return $this->getMockBuilder('Raven_Breadcrumbs')
-            ->disableOriginalConstructor()
-            ->getMock();
     }
 }


### PR DESCRIPTION
Updates the Sentry plugin to support v3.

Clearing breadcrumbs no longer seems supported, and doesn't make sense I don't think. Instead this plugin could clear all scopes, but I don't think that sounds like a good behaviour.

Thoughts?