### PR TITLE
Import Cleaner interface for autoconfiguration support

### DIFF
--- a/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
+++ b/src/Bundle/LongRunningBundle/DependencyInjection/LongRunningExtension.php
@@ -2,6 +2,7 @@
 
 namespace LongRunning\Bundle\LongRunningBundle\DependencyInjection;
 
+use LongRunning\Core\Cleaner;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Reference;


### PR DESCRIPTION
The `LongRunning\Core\Cleaner` interface isn't being imported into the bundle's extension class, so autoconfiguration is not working correctly since the container will be looking for a `\Cleaner` instance.