### PR TITLE
Packages should require long-running/core 1.0 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,7 @@ jobs:
                     php-version: ${{ matrix.php-version }}
                     coverage: none
             -   run: composer install --no-progress --ansi
+            -   run: vendor/bin/monorepo-builder bump-interdependency dev-main
             -   run: vendor/bin/monorepo-builder localize-composer-paths packages/${{ matrix.package }}/composer.json --ansi
             -   run: composer update --no-progress --ansi --working-dir packages/${{ matrix.package }}
             -   name: Split Tests of ${{ matrix.package }}

--- a/packages/doctrine-orm/composer.json
+++ b/packages/doctrine-orm/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "long-running/core": "dev-main",
+        "long-running/core": "^1.0",
         "psr/log": "^1.0.1",
         "doctrine/orm": "^2.7"
     },

--- a/packages/sentry/composer.json
+++ b/packages/sentry/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "long-running/core": "dev-main",
+        "long-running/core": "^1.0",
         "psr/log": "^1.0.1",
         "sentry/sdk": "^3.1"
     },


### PR DESCRIPTION
Before running the split tests, we bump the dependency to `dev-main`.