### PR TITLE
Letting assertion equals be strict

### DIFF
--- a/packages/core/tests/Functional/LongRunningExtensionTest.php
+++ b/packages/core/tests/Functional/LongRunningExtensionTest.php
@@ -36,7 +36,7 @@ final class LongRunningExtensionTest extends KernelTestCase
             CleanerTwo::class,
         ];
 
-        $this->assertEquals($expectedCleaners, array_map('get_class', $cleaners));
+        $this->assertSame($expectedCleaners, array_map('get_class', $cleaners));
 
         $this->cleaner->cleanUp();
     }

--- a/packages/doctrine-orm/tests/Functional/LongRunningExtensionTest.php
+++ b/packages/doctrine-orm/tests/Functional/LongRunningExtensionTest.php
@@ -38,7 +38,7 @@ final class LongRunningExtensionTest extends KernelTestCase
             ResetClosedEntityManagers::class,
         ];
 
-        $this->assertEquals($expectedCleaners, array_map('get_class', $cleaners));
+        $this->assertSame($expectedCleaners, array_map('get_class', $cleaners));
 
         $this->cleaner->cleanUp();
     }

--- a/packages/sentry/tests/Functional/LongRunningExtensionTest.php
+++ b/packages/sentry/tests/Functional/LongRunningExtensionTest.php
@@ -36,7 +36,7 @@ final class LongRunningExtensionTest extends KernelTestCase
             FlushSentryErrors::class,
         ];
 
-        $this->assertEquals($expectedCleaners, array_map('get_class', $cleaners));
+        $this->assertSame($expectedCleaners, array_map('get_class', $cleaners));
 
         $this->cleaner->cleanUp();
     }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assertion equals strict.